### PR TITLE
Move `onCompile` to `compiler.hooks.watchRun` because `compiler.hooks…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,14 +168,17 @@ function () {
             _this.options.onBuildStart = [];
           }
         }
-
+      });
+      compiler.hooks.watchRun.tap('WebpackShellPlugin', function (compilation, callback) {
         if (_this.options.onCompile.length) {
           console.log('Executing compile scripts');
 
-          for (var i = 0; i < _this.options.onCompile.length; i++) {
-            _this.handleScript(_this.options.onCompile[i]);
+          for (var ii = 0; ii < _this.options.onCompile.length; ii += 1) {
+            _this.handleScript(_this.options.onCompile[ii]);
           }
         }
+
+        callback();
       });
       compiler.hooks.afterEmit.tapAsync('WebpackShellPlugin', function (compilation, callback) {
         if (_this.options.onBuildEnd.length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-shell-plugin-alt",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Run shell commands before and after webpack builds",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/webpack-shell-plugin.js
+++ b/src/webpack-shell-plugin.js
@@ -88,13 +88,16 @@ export default class WebpackShellPlugin {
           this.options.onBuildStart = [];
         }
       }
+    });
 
+    compiler.hooks.watchRun.tap('WebpackShellPlugin', (compilation, callback) => {
       if (this.options.onCompile.length) {
         console.log('Executing compile scripts');
         for (let ii = 0; ii < this.options.onCompile.length; ii += 1) {
           this.handleScript(this.options.onCompile[ii]);
         }
       }
+      callback();
     });
 
     compiler.hooks.afterEmit.tapAsync('WebpackShellPlugin', (compilation, callback) => {


### PR DESCRIPTION
….compilation` fires a lot more then `watchRun`.